### PR TITLE
Cache .desktop file hashmap as JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,10 +344,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-channel"
@@ -481,8 +502,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -744,10 +767,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
+name = "halfbrown"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
+dependencies = [
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1222,6 +1260,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1438,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "simd-json",
  "tokio",
  "toml",
  "wayland-protocols 0.32.6",
@@ -1399,6 +1458,27 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-json"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b5602e4f1f7d358956f94cac1eff59220f34cf9e26d49f5fde5acef851cbed"
+dependencies = [
+ "getrandom",
+ "halfbrown",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1612,6 +1692,18 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "value-trait"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,25 +14,25 @@ glob = "0.3.2"
 gtk4 = "^0.9.5"
 gtk4-layer-shell = "0.4.0"
 meval = "0.2.0"
-nix = {version = "0.29.0", features = ["fs"]}
+nix = { version = "0.29.0", features = ["fs"] }
 once_cell = "1.20.2"
 open = "5.3.2"
 rayon = "1.10.0"
 regex = "1.11.1"
-serde = {version = "1.0.217", features=["derive"]}
+serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"
-tokio = {version = "1.43.0", features=["full"]}
+tokio = { version = "1.43.0", features = ["full"] }
 toml = "0.8.19"
 wayland-protocols = "0.32.5"
+simd-json = "0.15"
 
 [package.metadata]
 assets = ["resources/*"]
 
 [profile.release]
-opt-level = 3 
+opt-level = 3
 lto = "fat"
 panic = 'abort'
 
 [dev-dependencies]
 criterion = "0.3"
-

--- a/src/loader/application_loader.rs
+++ b/src/loader/application_loader.rs
@@ -1,6 +1,7 @@
 use glob::Pattern;
 use rayon::prelude::*;
 use regex::Regex;
+use simd_json;
 use std::collections::HashMap;
 use std::fs::{self, File};
 
@@ -45,7 +46,7 @@ impl Loader {
 
         // Parse user-specified 'sherlock_alias.json' file
         let aliases: HashMap<String, SherlockAlias> = match File::open(&sherlock_flags.alias) {
-            Ok(f) => serde_json::from_reader(f).map_err(|e| SherlockError {
+            Ok(f) => simd_json::from_reader(f).map_err(|e| SherlockError {
                 error: SherlockErrorType::FileReadError(sherlock_flags.alias.to_string()),
                 traceback: e.to_string(),
             })?,

--- a/src/loader/application_loader.rs
+++ b/src/loader/application_loader.rs
@@ -2,13 +2,12 @@ use glob::Pattern;
 use rayon::prelude::*;
 use regex::Regex;
 use std::collections::HashMap;
-use std::fs::{self, read_to_string};
-use std::path::Path;
+use std::fs::{self, File};
 
-use super::util::{SherlockError, SherlockFlags, SherlockErrorType};
+use super::util::{SherlockError, SherlockErrorType, SherlockFlags};
 use super::{util, Loader};
 use crate::CONFIG;
-use util::{read_file, AppData, SherlockAlias};
+use util::{read_file, read_lines, AppData, SherlockAlias};
 
 impl Loader {
     pub fn load_applications(
@@ -18,9 +17,6 @@ impl Loader {
             error: SherlockErrorType::ConfigError(None),
             traceback: format!(""),
         })?;
-        // Define required paths for application parsing
-        let sherlock_ignore_path = sherlock_flags.ignore.clone();
-        let sherlock_alias_path = sherlock_flags.alias.clone();
         let system_apps = "/usr/share/applications/";
 
         // Parse needed fields from the '.desktop'
@@ -35,33 +31,30 @@ impl Loader {
         };
 
         // Parse user-specified 'sherlockignore' file
-        let mut ignore_apps: Vec<Pattern> = Default::default();
-        if Path::new(&sherlock_ignore_path).exists() {
-            ignore_apps = read_to_string(&sherlock_ignore_path)
-                .map_err(|e| SherlockError {
-                    error: SherlockErrorType::FileReadError(sherlock_ignore_path),
-                    traceback: e.to_string(),
-                })?
-                .lines()
-                .filter_map(|line| {
-                    let line = line.to_lowercase();
-                    Pattern::new(&line).ok()
-                })
-                .collect::<Vec<Pattern>>();
-        }
+        let ignore_apps: Vec<Pattern> = match read_lines(&sherlock_flags.ignore) {
+            Ok(lines) => lines
+                .map_while(Result::ok)
+                .filter_map(|line| Pattern::new(&line.to_lowercase()).ok())
+                .collect(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Default::default(),
+            Err(e) => Err(SherlockError {
+                error: SherlockErrorType::FileReadError(sherlock_flags.ignore.to_string()),
+                traceback: e.to_string(),
+            })?,
+        };
 
         // Parse user-specified 'sherlock_alias.json' file
-        let mut aliases: HashMap<String, SherlockAlias> = Default::default();
-        if Path::new(&sherlock_alias_path).exists() {
-            let json_data = read_to_string(&sherlock_alias_path).map_err(|e| SherlockError {
-                error: SherlockErrorType::FileReadError(sherlock_alias_path.clone()),
+        let aliases: HashMap<String, SherlockAlias> = match File::open(&sherlock_flags.alias) {
+            Ok(f) => serde_json::from_reader(f).map_err(|e| SherlockError {
+                error: SherlockErrorType::FileReadError(sherlock_flags.alias.to_string()),
                 traceback: e.to_string(),
-            })?;
-            aliases = serde_json::from_str(&json_data).map_err(|e| SherlockError {
-                error: SherlockErrorType::FileParseError(sherlock_alias_path),
+            })?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Default::default(),
+            Err(e) => Err(SherlockError {
+                error: SherlockErrorType::FileReadError(sherlock_flags.alias.to_string()),
                 traceback: e.to_string(),
-            })?
-        }
+            })?,
+        };
 
         // Gather '.desktop' files
         let dektop_files: Vec<_> = fs::read_dir(system_apps)
@@ -151,7 +144,7 @@ fn should_ignore(ignore_apps: &Vec<Pattern>, app: &String) -> bool {
 }
 
 fn get_regex_patterns() -> Result<(Regex, Regex, Regex, Regex, Regex, Regex), SherlockError> {
-    fn construct_pattern(key: &str)->Result<Regex, SherlockError>{
+    fn construct_pattern(key: &str) -> Result<Regex, SherlockError> {
         let pattern = format!(r"(?i){}\s*=\s*(.*)\n", key);
         Regex::new(&pattern).map_err(|e| SherlockError {
             error: SherlockErrorType::RegexError(key.to_string()),

--- a/src/loader/flag_loader.rs
+++ b/src/loader/flag_loader.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use super::{
-    util::{SherlockError, SherlockFlags, SherlockErrorType},
+    util::{SherlockError, SherlockErrorType, SherlockFlags},
     Loader,
 };
 
@@ -49,6 +49,7 @@ impl SherlockFlags {
             alias: extract_flag_value("--alias", defaults.alias),
             display_raw: check_flag_existance("--display-raw"),
             center_raw: check_flag_existance("--center"),
+            cache: extract_flag_value("--cache", defaults.cache),
         })
     }
 
@@ -65,6 +66,7 @@ impl SherlockFlags {
             alias: format!("{}/.config/sherlock/sherlock_alias.json", home_dir),
             display_raw: false,
             center_raw: false,
+            cache: format!("{}/.cache/sherlock_desktop_cache.json", home_dir),
         })
     }
 }
@@ -85,7 +87,8 @@ pub fn print_help() -> Result<(), SherlockError> {
         ("--style", "Set the style configuration file."),
         ("--ignore", "Specify the sherlock ignore file"),
         ("--alias", "Specify the sherlock alias file (.json)."),
-        ("--display-raw", "Force Sherlock to use a singular tile to display the piped content")
+        ("--display-raw", "Force Sherlock to use a singular tile to display the piped content"),
+        ("--cache", "Specify the sherlock cache file (.json).")
     ];
 
     // Print header

--- a/src/loader/launcher_loader.rs
+++ b/src/loader/launcher_loader.rs
@@ -11,9 +11,9 @@ use app_launcher::App;
 use bulk_text_launcher::BulkText;
 use calc_launcher::Calc;
 use clipboard_launcher::Clp;
+use simd_json;
 use system_cmd_launcher::SystemCommand;
 use web_launcher::Web;
-
 
 use super::{
     util::{self, SherlockError, SherlockErrorType},
@@ -115,7 +115,7 @@ fn parse_launcher_configs(
         // Tries to load the user-specified launchers. If it failes, it returns a non breaking
         // error.
         match File::open(&sherlock_flags.fallback) {
-            Ok(f) => serde_json::from_reader(f).map_err(|e| SherlockError {
+            Ok(f) => simd_json::from_reader(f).map_err(|e| SherlockError {
                 error: SherlockErrorType::FileParseError(sherlock_flags.fallback.to_string()),
                 traceback: e.to_string(),
             }),

--- a/src/loader/util.rs
+++ b/src/loader/util.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read};
@@ -25,7 +25,7 @@ pub struct CommandConfig {
     pub args: serde_json::Value,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct AppData {
     pub icon: String,
     pub exec: String,
@@ -34,7 +34,7 @@ pub struct AppData {
     pub tag_end: Option<String>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SherlockFlags {
     pub config: String,
     pub fallback: String,
@@ -43,6 +43,7 @@ pub struct SherlockFlags {
     pub alias: String,
     pub display_raw: bool,
     pub center_raw: bool,
+    pub cache: String,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/loader/util.rs
+++ b/src/loader/util.rs
@@ -1,7 +1,8 @@
 use serde::Deserialize;
 use std::env;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{self, BufRead, BufReader, Read};
+use std::path::Path;
 use std::process::Command;
 
 #[derive(Deserialize, Debug)]
@@ -207,6 +208,14 @@ pub fn read_file(file_path: &str) -> std::io::Result<String> {
     let mut content = String::new();
     reader.read_to_string(&mut content)?;
     Ok(content)
+}
+
+pub fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(filename)?;
+    Ok(io::BufReader::new(file).lines())
 }
 
 pub fn default_terminal() -> String {


### PR DESCRIPTION
On a test system with a quite fast SSD and not that many .desktop files, application_loader goes from taking 2.5 milliseconds to taking roughly 60-100 microseconds.

This is only viable with `simd_json` - with `serde_json`, the reading the cache is actually *slower* than building the data directly.

(I started writing this before the parallel parsing was introduced where the benefit was much larger, but it's still nice to slice time off startup.)

Depends on https://github.com/Skxxtz/sherlock/pull/1