### PR TITLE
ci: Initial github action workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build 
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "**" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  GTK4_LAYER_SHELL_VERSION: v1.1.0
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    # Ubuntu doesn't have gtk4-layer-shell packaged, so we need to prepare that first
+    - name: Pull apt
+      run: sudo apt-get update
+    - name: Install gtk4-layer-shell dependencies
+      run: sudo apt install meson libwayland-dev wayland-protocols libgtk-4-dev gobject-introspection libgirepository1.0-dev valac gtk-doc-tools
+    - name: Unpack gtk4-layer-shell
+      run: curl -L "https://github.com/wmww/gtk4-layer-shell/archive/refs/tags/${GTK4_LAYER_SHELL_VERSION}.tar.gz" | tar -zx && mv gtk4-layer-shell-* gtk4-layer-shell
+    - name: Prepare gtk4-layer-shell
+      run: meson setup gtk4-layer-shell-build gtk4-layer-shell
+    - name: Install gtk4-layer-shell
+      run: sudo ninja -C gtk4-layer-shell-build install
+
+    # Build, test and check formatting
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Check formatting
+      run: cargo fmt --check


### PR DESCRIPTION
We build and install `gtk4-layer-shell` ourselves as it is not officially packaged for Ubuntu.

Fails because unstable doens't pass cargo-fmt right now. I personally sometimes use a cargo-fmt pre-commit git hook to avoid committing unformatted code.