### PR TITLE
add home application dir

### DIFF
--- a/src/loader/application_loader.rs
+++ b/src/loader/application_loader.rs
@@ -261,7 +261,16 @@ fn get_applications_dir() -> HashSet<PathBuf> {
                 .collect();
             app_dirs
         }
-        _ => HashSet::from([PathBuf::from("/usr/share/applications/")]),
+        _ => {
+            let mut app_dirs = HashSet::from([PathBuf::from("/usr/share/applications/")]);
+
+            // Add ~/.local/share/applications/ if HOME is available
+            if let Ok(home) = env::var("HOME") {
+                app_dirs.insert(PathBuf::from(home).join(".local/share/applications/"));
+            }
+
+            app_dirs
+        }
     }
 }
 


### PR DESCRIPTION
I noticed my Jetbrains tools were not showing up, these were stored in ~/.local/share/applications.

if the XDG_DATA_DIRS variable is not set it only loads /usr/share/applications/

I added some code that should also add ~/.local/share/applications.


### BIG DISCLAIMER

to be totally honest: I have never coded Rust in my life, to be even more honest, i generated this code with Claude 3.7.

I know lots of other languages and i checked the code with a good old 'this looks fine and does what it is supposed to do with the 5 minutes Rust I learned from looking at the code base'.

TLDR: please thoroughly check this code. even if it is just a small change ;) 