### PR TITLE
Corrected `surpress` to `suppress`

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ curl -O https://raw.githubusercontent.com/skxxtz/sherlock/main/docs/examples/fal
 curl -O https://raw.githubusercontent.com/skxxtz/sherlock/main/docs/examples/sherlock_alias.json
 ```
 #### Warnings after startup
-If you're getting warnings after startup, you can press `return` to access the main application. Alternatively you can set the `try_surpress_warnings` key in the config file to true. This will prevent any warnings to be shown. The same thing can be done for errors. However, if you surpress errors, the application might not work as expected.
+If you're getting warnings after startup, you can press `return` to access the main application. Alternatively you can set the `try_suppress_warnings` key in the config file to true. This will prevent any warnings to be shown. The same thing can be done for errors. However, if you suppress errors, the application might not work as expected.
 
 #### **Keybind Setup**
 To launch Sherlock, you can either type `sherlock` into the command line or bind it to a key. The latter is recommended.

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -4,8 +4,8 @@ calendar_client         =   "thunderbird"                           # For fetchi
 terminal                =   "kitty"                                 # Used to start applications
 
 [debug]
-try_surpress_errors     =   false                                   # Disables the error screen for errors
-try_surpress_warnings   =   true                                    # Disables the error screen for warnings
+try_suppress_errors     =   false                                   # Disables the error screen for errors
+try_suppress_warnings   =   true                                    # Disables the error screen for warnings
 
 [appearance]
 width                   =   900                                     # Sets the width of the main window

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ curl -O https://raw.githubusercontent.com/skxxtz/sherlock/main/docs/examples/fal
 curl -O https://raw.githubusercontent.com/skxxtz/sherlock/main/docs/examples/sherlock_alias.json
 ```
 ### Warnings after startup
-If you're getting warnings after startup, you can press `return` to access the main application. Alternatively you can set the `try_surpress_warnings` key in the config file to true. This will prevent any warnings to be shown. The same thing can be done for errors. However, if you surpress errors, the application might not work as expected.
+If you're getting warnings after startup, you can press `return` to access the main application. Alternatively you can set the `try_suppress_warnings` key in the config file to true. This will prevent any warnings to be shown. The same thing can be done for errors. However, if you suppress errors, the application might not work as expected.
 
 ### **Keybind Setup**
 To launch Sherlock, you can either type `sherlock` into the command line or bind it to a key. The latter is recommended.


### PR DESCRIPTION
Corrected `surpress` to `suppress` in `docs/examples/config.toml`

Without this, copying the example config leads to those options not working correctly