### PR TITLE
feat: launch prefix

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -54,6 +54,7 @@ The configuration file for Sherlock is located at `~/.config/sherlock/config.tom
 | `cache` | `~/.cache/sherlock_desktop_cache.json`   | Overrides the default caching location. ||
 | `daemonize` | `false`     | If set to `true`, Sherlock will run in daemon mode. This will consume more memory because the rendered application will be kept in memory. Daemonizing will allow faster startup times. Send the `open` message to socket `/tmp/sherlock_daemon.socket` to open the window. |[Daemonizing](https://github.com/Skxxtz/sherlock/blob/documentation/docs/features/daemonizing.md)|
 | `animate` | `true`   | Sets if startup animation should play. (Only works on daemonize=false) ||
+| `launch_prefix` | `None` | Command prefix used for launching applications, e.g., `"uwsm app --"`. ||
 ---
 ## Binds Section `[binds]`
 

--- a/src/actions/applaunch.rs
+++ b/src/actions/applaunch.rs
@@ -1,10 +1,23 @@
+use crate::loader::util::{SherlockError, SherlockErrorType};
+use crate::CONFIG;
 use std::{
     os::unix::process::CommandExt,
     process::{exit, Command, Stdio},
 };
 
-pub fn applaunch(exec: &str) {
-    let parts: Vec<String> = exec.split_whitespace().map(String::from).collect();
+pub fn applaunch(exec: &str) -> Result<(), SherlockError> {
+    let config = CONFIG.get().ok_or(SherlockError {
+        error: SherlockErrorType::ConfigError(None),
+        traceback: format!(""),
+    })?;
+
+    let parts: Vec<String> = match &config.behavior.launch_prefix {
+        Some(prefix) => String::from(prefix) + " " + exec,
+        None => String::from(exec),
+    }
+    .split_whitespace()
+    .map(String::from)
+    .collect();
 
     if parts.is_empty() {
         eprintln!("Error: Command is empty");
@@ -32,4 +45,5 @@ pub fn applaunch(exec: &str) {
 
     // TODO make error handling so that error tile will show up
     let _output = command.spawn();
+    Ok(())
 }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -34,7 +34,7 @@ pub fn execute_from_attrs(row: &SherlockRow, attrs: &HashMap<String, String>) {
             }
             "app_launcher" => {
                 let exec = attrs.get("exec").map_or("", |s| s.as_str());
-                applaunch::applaunch(exec);
+                let _ = applaunch::applaunch(exec);
                 increment(&exec);
                 eval_exit();
             }

--- a/src/loader/util.rs
+++ b/src/loader/util.rs
@@ -321,6 +321,7 @@ pub struct ConfigBehavior {
     #[serde(default = "default_true")]
     pub animate: bool,
     pub field: Option<String>,
+    pub launch_prefix: Option<String>,
 }
 impl Default for ConfigBehavior {
     fn default() -> Self {
@@ -330,6 +331,7 @@ impl Default for ConfigBehavior {
             daemonize: false,
             animate: true,
             field: None,
+            launch_prefix: None,
         }
     }
 }


### PR DESCRIPTION
Hello,

I noticed there isn't a way to launch applications with a custom command, e.g., `uwsm app --`, so I implemented it :)
When I finished it, I realized, that maybe I should've made it an argument for the app launcher, so I might redo it when I have more time.
I was also wondering if it would make sense to add the prefix to the command launcher? On one hand it is mostly for user defined commands, so it could be seen as unwanted, but on the other hand it is also used for launching the browser from the web launcher.

I am also quite new to Rust and contributing to open source, so feel free to provide suggestions and constructive criticism.