### PR TITLE
(nix) home-manager 'style' option

### DIFF
--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -78,6 +78,12 @@ in {
         };
       };
     };
+
+    style = mkOption {
+      description = "CSS content for Sherlock UI styling, written to 'main.css'";
+      default = null;
+      type = nullOr str;
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -100,5 +106,8 @@ in {
         xdg.configFile."sherlock/fallback.json".text = builtins.toJSON cfg.settings.launchers;
       })
     ]))
+    (mkIf (cfg.style != null) {
+      xdg.configFile."sherlock/main.css".text = cfg.style;
+    })
   ]);
 }


### PR DESCRIPTION
For using home-manager module via nix, adds a `style` option to configure the css of sherlock. e.g.

```nix
programs.sherlock = {
  enable = true;
  settings = {};
  style = ''
     * {
          padding: 0px;
          margin: 0px;
          outline-style: dashed;
      }
  '';
};
```

Changes are simple, not difficult if this belongs to a different branch/destination. Happy to iterate on any issues. Already tested locally and works fine.