### PR TITLE
examples: update deprecated config key

### DIFF
--- a/docs/examples/config.json
+++ b/docs/examples/config.json
@@ -30,7 +30,7 @@
         "caching": true,
         "cache": "~/.cache/sherlock_desktop_cache.json",
         "daemonize": false,
-        "animation": true,
+        "animate": true,
         "global_prefix": "",
         "global_flags": ""
     },

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -29,7 +29,7 @@ status_bar              =   true
 caching                 =   true                                    
 cache                   =   "~/.cache/sherlock_desktop_cache.json"  
 daemonize               =   false                                   
-animation               =   true                                    
+animate                 =   true                                    
 global_prefix           =   ""                                   
 global_flags            =   ""                                    
 


### PR DESCRIPTION
This PR updates the deprecated config key `behavior.animation` to `behavior.animate` to avoid confusion

#35 