### PR TITLE
feature: opacity

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -46,6 +46,7 @@ The configuration file for Sherlock is located at `~/.config/sherlock/config.tom
 | `search_icon`    | `true`        | Enables or disables the use of the search icon |
 | `use_base_css`    | `true`        | Enables or disables the extension of Sherlock's default style sheet. |
 | `status_bar`    | `true`        | Enables or disables the status bar. |
+| `opacity` | `1.0` | Controls the opacity of the window. Allowed range: `0.1 - 1.0` |
 
 ---
 ## Behavior Section `[behavior]`

--- a/docs/examples/config.json
+++ b/docs/examples/config.json
@@ -24,7 +24,8 @@
         "icon_size": 22,
         "search_icon": true,
         "use_base_css": true,
-        "status_bar": true
+        "status_bar": true,
+        "opacity": 1.0
     },
     "behavior": {
         "caching": true,

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -24,6 +24,7 @@ icon_size               =   22
 search_icon             =   true                                        
 use_base_css            =   true
 status_bar              =   true
+opacity                 =   1.0
 
 [behavior]
 caching                 =   true                                    

--- a/src/loader/util.rs
+++ b/src/loader/util.rs
@@ -315,6 +315,8 @@ pub struct ConfigAppearance {
     pub use_base_css: bool,
     #[serde(default = "default_true")]
     pub status_bar: bool,
+    #[serde(default)]
+    pub opacity: f64,
 }
 impl Default for ConfigAppearance {
     fn default() -> Self {
@@ -327,6 +329,7 @@ impl Default for ConfigAppearance {
             search_icon: false,
             use_base_css: true,
             status_bar: true,
+            opacity: 1.0,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,22 @@ async fn main() {
         };
         stack.add_named(&search_stack, Some("search-page"));
 
+        // Notify the user about the value not having any effect to avoid confusion
+        if let Some(c) = CONFIG.get() {
+            let opacity = c.appearance.opacity;
+
+            if opacity > 1.0 || opacity < 0.1 {
+                non_breaking.push(SherlockError {
+                    error: SherlockErrorType::ConfigError(Some(format!(
+                        "The opacity value of {} exceeds the allowed range (0.1 - 1.0) and will be automatically set to {}.",
+                        opacity,
+                        opacity.clamp(0.1, 1.0)
+                    ))),
+                    traceback: String::new(),
+                });
+            }
+        }
+
         // Logic for the Error-View
         let error_stack = ui::error_view::errors(&error_list, &non_breaking, &current_stack_page);
         stack.add_named(&error_stack, Some("error-page"));

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -13,9 +13,15 @@ use super::tiles::util::TextViewTileBuilder;
 
 pub fn window(application: &Application) -> (ApplicationWindow, Stack, Rc<RefCell<String>>) {
     // 617 with, 593 without notification bar
-    let (width, height) = CONFIG.get().map_or_else(
-        || (900, 593),
-        |config| (config.appearance.width, config.appearance.height),
+    let (width, height, opacity) = CONFIG.get().map_or_else(
+        || (900, 593, 1.0),
+        |config| {
+            (
+                config.appearance.width,
+                config.appearance.height,
+                config.appearance.opacity,
+            )
+        },
     );
 
     let current_stack_page = Rc::new(RefCell::new(String::from("search-page")));
@@ -25,6 +31,7 @@ pub fn window(application: &Application) -> (ApplicationWindow, Stack, Rc<RefCel
         .default_width(width)
         .default_height(height)
         .resizable(false)
+        .opacity(opacity.clamp(0.1, 1.0)) // Avoid overflow and full-transparency
         .build();
 
     window.init_layer_shell();

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -35,6 +35,7 @@ pub fn window(application: &Application) -> (ApplicationWindow, Stack, Rc<RefCel
         .build();
 
     window.init_layer_shell();
+    window.set_namespace("sherlock");
     window.set_layer(Layer::Overlay);
     window.set_keyboard_mode(gtk4_layer_shell::KeyboardMode::Exclusive);
 


### PR DESCRIPTION
This PR adds a new config value which controls the opacity of the window. You can set a value under `appearance.opacity` to control it. The allowed range is `0.1 - 1.0` to avoid overflow which results in panics. The minimum threshold is defined so you don't accidentally vanish your window. If the value was clamped, a warning will be shown to the user to avoid any confusion:

![image](https://github.com/user-attachments/assets/1d46099f-532c-4e87-9b27-7a70346adbe8)

This feature was directly documented aswell.

Additionally, this PR sets the namespace of the GTK layer to `sherlock` instead of the default (`gtk-layer-shell`), so the layer can be selected easier using `layerrule` (to add blur, for example).