### PR TITLE
Handle quoted values in desktop files

### DIFF
--- a/src/loader/application_loader.rs
+++ b/src/loader/application_loader.rs
@@ -265,7 +265,7 @@ fn should_ignore(ignore_apps: &Vec<Pattern>, app: &str) -> bool {
 
 fn get_regex_patterns() -> Result<(Regex, Regex, Regex, Regex, Regex, Regex), SherlockError> {
     fn construct_pattern(key: &str) -> Result<Regex, SherlockError> {
-        let pattern = format!(r"(?i)\n{}\s*=\s*(.*)\n", key);
+        let pattern = format!(r#"(?i)\n{}\s*=\s*"?([^"\n]*)"?\n"#, key);
         Regex::new(&pattern).map_err(|e| SherlockError {
             error: SherlockErrorType::RegexError(key.to_string()),
             traceback: e.to_string(),


### PR DESCRIPTION
Take this desktop file for the Yubico Authenticator as an example:
```
[Desktop Entry]
Name=Yubico Authenticator
GenericName=Yubico Authenticator
Exec="/opt/yubico-authenticator/authenticator"
Icon=/usr/share/pixmaps/com.yubico.yubioath.png
Type=Application
Categories=Utility;
Keywords=Yubico;Authenticator;
```
The previous regex captured the quotes of the exec line too, causing the final exec to fail.

This PR changes the regex to ignore a leading and trailing quote.

Still not entirely happy with this, but it works and fixes the immediate issue for me.

In the long term this should probably be done with proper parsing instead of regex.