### PR TITLE
Refactored home-manager.nix to be more consistent

### DIFF
--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -75,14 +75,13 @@ in {
             default = [];
             type = nullOr (listOf launcherType);
           };
+          style = mkOption {
+            description = "CSS content for Sherlock UI styling, written to 'main.css'";
+            default = "";
+            type = nullOr lines;
+          };
         };
       };
-    };
-
-    style = mkOption {
-      description = "CSS content for Sherlock UI styling, written to 'main.css'";
-      default = "";
-      type = nullOr lines;
     };
   };
 

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -104,8 +104,8 @@ in {
       (mkIf (cfg.settings.launchers != null) {
         xdg.configFile."sherlock/fallback.json".text = builtins.toJSON cfg.settings.launchers;
       })
-      (mkIf (cfg.style != null) {
-        xdg.configFile."sherlock/main.css".text = cfg.style;
+      (mkIf (cfg.settings.style != null) {
+        xdg.configFile."sherlock/main.css".text = cfg.settings.style;
       })
     ]))
   ]);

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -81,8 +81,8 @@ in {
 
     style = mkOption {
       description = "CSS content for Sherlock UI styling, written to 'main.css'";
-      default = null;
-      type = nullOr str;
+      default = "";
+      type = nullOr lines;
     };
   };
 
@@ -105,9 +105,9 @@ in {
       (mkIf (cfg.settings.launchers != null) {
         xdg.configFile."sherlock/fallback.json".text = builtins.toJSON cfg.settings.launchers;
       })
+      (mkIf (cfg.style != null) {
+        xdg.configFile."sherlock/main.css".text = cfg.style;
+      })
     ]))
-    (mkIf (cfg.style != null) {
-      xdg.configFile."sherlock/main.css".text = cfg.style;
-    })
   ]);
 }


### PR DESCRIPTION
I didn't get a chance to review the changes made to the nix flake, my bad! 

However, I noticed that the new options don't follow the conventions that I had set for the home-manager module.

I never formalized this, so maybe I'll document this better somewhere else, but the structure of the module is setup so that:

 - If `programs.sherlock.config` is enabled, all config files will be created by default, empty
 - For each file, it can be optionally managed with `home-manager`, it it's `null` the file is not symlinked from the nix-store and is therefore easier to edit when making lots of adjustments. If it's non-`null`, the file is managed by home-manager (symlinked, making it reproducible but requires rebuilding the system to edit)
 
The changes in this commit make that behaviour consistent for all config files, now including `main.css`. 
