### PR TITLE
add homemanager package options, since sherlock is now in nixpkgs!

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,12 +14,7 @@
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    home-manager,
-    ...
-  } @ inputs:
+  outputs = {nixpkgs, ...} @ inputs:
     inputs.flake-parts.lib.mkFlake {inherit inputs;} {
       # sherlock currently only supports linux
       systems = [
@@ -28,8 +23,8 @@
       ];
 
       flake = rec {
-        homeManagerModules.default = import ./nix/home-manager.nix self;
-        homeModules.default = homeManagerModules.default;
+        homeModules.default = import ./nix/home-manager.nix;
+        homeManagerModules.default = homeModules.default;
       };
 
       perSystem = {system, ...}: let

--- a/flake.nix
+++ b/flake.nix
@@ -27,13 +27,12 @@
         "aarch64-linux"
       ];
 
-      flake.homeManagerModules.default = import ./nix/home-manager.nix self;
+      flake = rec {
+        homeManagerModules.default = import ./nix/home-manager.nix self;
+        homeModules.default = homeManagerModules.default;
+      };
 
-      perSystem = {
-        system,
-        stdenv,
-        ...
-      }: let
+      perSystem = {system, ...}: let
         name = "sherlock";
         version = "0.1.10";
 

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -33,6 +33,9 @@ self: {
 in {
   options.programs.sherlock = with types; {
     enable = lib.mkEnableOption "Manage sherlock & config files with home-manager module." // {default = false;};
+    package = lib.mkPackageOption pkgs "sherlock" {
+      default = ["sherlock-launcher"];
+    };
 
     settings = mkOption {
       description = "Sherlock settings, seperated by config file.";
@@ -87,9 +90,7 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
-      # always install the package, because why else would you include the home-manager module.
-      # this could be made more customizable if `flake.nix` outputted nightly/unstable & release packages
-      home.packages = [self.packages.${pkgs.system}.default];
+      home.packages = [cfg.package];
     }
     (mkIf (cfg.settings != null) (mkMerge [
       (mkIf (cfg.settings.aliases != null) {

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,4 +1,4 @@
-self: {
+{
   lib,
   config,
   pkgs,


### PR DESCRIPTION
This should probably be merged when `sherlock-launcher` is in [`nixpkgs-untable`](https://nixpk.gs/pr-tracker.html?pr=403004)

PS: made some small changed to the flake, lmk if disliked