### PR TITLE
Add `meta.mainProgram` attribute to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,8 @@
             inherit cargoArtifacts;
             pname = "${name}";
             version = "${version}";
+
+            meta = {mainProgram = "sherlock";};
           });
       in {
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
Its absence was causing some issues with `lib.getExe` calls on Nix.

I have not added more metadata, like license, because CC-by-NC will be flagged as unfree. I'll add that (and other things) if you and @Vanta1 agree.