### PR TITLE
XDG-Variables

### DIFF
--- a/src/actions/util.rs
+++ b/src/actions/util.rs
@@ -51,7 +51,7 @@ pub fn clear_cached_files() -> Result<(), SherlockError> {
 
 pub fn reset_app_counter() -> Result<(), SherlockError> {
     let home = home_dir()?;
-    fs::remove_file(home.join(".sherlock/counts.json")).map_err(|e| {
+    fs::remove_file(home.join(".config/sherlock/counts.json")).map_err(|e| {
         sherlock_error!(
             SherlockErrorType::FileRemoveError(home.join(".sherlock/counts.json")),
             e.to_string()

--- a/src/actions/util.rs
+++ b/src/actions/util.rs
@@ -53,7 +53,7 @@ pub fn reset_app_counter() -> Result<(), SherlockError> {
     let home = home_dir()?;
     fs::remove_file(home.join(".cache/sherlock/counts.json")).map_err(|e| {
         sherlock_error!(
-            SherlockErrorType::FileRemoveError(home.join(".sherlock/counts.json")),
+            SherlockErrorType::FileRemoveError(home.join(".cache/sherlock/counts.json")),
             e.to_string()
         )
     })

--- a/src/actions/util.rs
+++ b/src/actions/util.rs
@@ -51,7 +51,7 @@ pub fn clear_cached_files() -> Result<(), SherlockError> {
 
 pub fn reset_app_counter() -> Result<(), SherlockError> {
     let home = home_dir()?;
-    fs::remove_file(home.join(".config/sherlock/counts.json")).map_err(|e| {
+    fs::remove_file(home.join(".cache/sherlock/counts.json")).map_err(|e| {
         sherlock_error!(
             SherlockErrorType::FileRemoveError(home.join(".sherlock/counts.json")),
             e.to_string()

--- a/src/loader/util.rs
+++ b/src/loader/util.rs
@@ -243,7 +243,7 @@ impl CounterReader {
             )
         })?;
         let home_dir = PathBuf::from(home);
-        let path = home_dir.join(".sherlock/counts.json");
+        let path = home_dir.join(".cache/sherlock/counts.json");
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(|e| {
                 sherlock_error!(

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -161,7 +161,7 @@ pub struct SherlockAction {
     pub on: u32,
     pub action: String,
 }
-pub struct Sherlocker {
+pub struct SherlockCounter {
     path: PathBuf,
 }
 impl SherlockCounter {

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -161,7 +161,7 @@ pub struct SherlockAction {
     pub on: u32,
     pub action: String,
 }
-pub struct SherlockCounter {
+pub struct Sherlocker {
     path: PathBuf,
 }
 impl SherlockCounter {
@@ -173,7 +173,7 @@ impl SherlockCounter {
             )
         })?;
         let home_dir = PathBuf::from(home);
-        let path = home_dir.join(".sherlock/sherlock_count");
+        let path = home_dir.join(".cache/sherlock/sherlock_count");
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(|e| {
                 sherlock_error!(


### PR DESCRIPTION
export XDG_CONFIG_HOME="${HOME}/.config"
This should allow for a means of setting a local env to replace where things are kept in a more modular manner.
Example for zsh
```
cat .zshenv                                     
# XDG Base Directory Specification
export XDG_DATA_HOME="${HOME}/.local/share"
export XDG_CONFIG_HOME="${HOME}/.config"
export XDG_STATE_HOME="${HOME}/.local/state"
export XDG_CACHE_HOME="${HOME}/.cache"
export ZDOTDIR="${XDG_CONFIG_HOME}/zsh"```