### PR TITLE
fix: create "~/.sherlock/" if it doesn't exist

### DIFF
--- a/src/actions/commandlaunch.rs
+++ b/src/actions/commandlaunch.rs
@@ -31,7 +31,7 @@ pub fn command_launch(exec: &str, keyword: &str) -> Result<(), SherlockError> {
 
 pub fn asynchronous_execution(cmd: &str, prefix: &str, flags: &str) -> Result<(), SherlockError> {
     let raw_command = format!("{}{}{}", prefix, cmd, flags).replace(r#"\""#, "'");
-    sher_log!(format!(r#"Spawning command "{}""#, raw_command));
+    sher_log!(format!(r#"Spawning command "{}""#, raw_command))?;
 
     let mut command = Command::new("sh");
     command.arg("-c").arg(raw_command.clone());
@@ -43,7 +43,7 @@ pub fn asynchronous_execution(cmd: &str, prefix: &str, flags: &str) -> Result<()
 
     // Move command string into task
     let child = command.spawn().map_err(|e| {
-        sher_log!(format!(
+        let _ = sher_log!(format!(
             "Failed to spawn command: {}\nError: {}",
             raw_command, e
         ));
@@ -57,11 +57,11 @@ pub fn asynchronous_execution(cmd: &str, prefix: &str, flags: &str) -> Result<()
         let result = match child.wait_with_output() {
             Ok(output) => {
                 if output.status.success() {
-                    sher_log!(format!("Command succeeded: {}", raw_command));
+                    let _ = sher_log!(format!("Command succeeded: {}", raw_command));
                     Ok(())
                 } else {
                     let stderr = String::from_utf8_lossy(&output.stderr);
-                    sher_log!(format!(
+                    let _ = sher_log!(format!(
                         "Command failed: {}\nStderr: {}",
                         raw_command, stderr
                     ));
@@ -72,7 +72,7 @@ pub fn asynchronous_execution(cmd: &str, prefix: &str, flags: &str) -> Result<()
                 }
             }
             Err(e) => {
-                sher_log!(format!(
+                let _ = sher_log!(format!(
                     "Failed to wait for command: {}\nError: {}",
                     raw_command, e
                 ));

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -67,7 +67,7 @@ impl SherlockAPI {
         }
         if !self.queue.is_empty() {
             self.queue.iter().for_each(|wait| {
-                sher_log!(format!("Action {} stays in queue", wait));
+                let _ = sher_log!(format!("Action {} stays in queue", wait));
             });
         }
     }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -27,7 +27,7 @@ impl SherlockServer {
             async move {
                 while let Ok(msg) = receiver.recv().await {
                     if let Ok(cmd) = serde_json::from_str::<ApiCall>(&msg) {
-                        sher_log!(format!("Incoming api request: {}", cmd));
+                        let _ = sher_log!(format!("Incoming api request: {}", cmd));
                         api.borrow_mut().await_request(cmd);
                     } else if let Some(mut data) = PipedData::new(&msg) {
                         if let Some(settings) = data.settings.take() {
@@ -46,7 +46,7 @@ impl SherlockServer {
                             api.borrow_mut().await_request(request);
                         }
                     } else {
-                        sher_log!(format!("Failed to deserialize api call(s): {}", msg));
+                        let _ = sher_log!(format!("Failed to deserialize api call(s): {}", msg));
                     }
                     api.borrow_mut().flush();
                 }

--- a/src/daemon/daemon.rs
+++ b/src/daemon/daemon.rs
@@ -15,7 +15,7 @@ impl SherlockDaemon {
     pub async fn new(pipeline: async_channel::Sender<String>) -> Self {
         let _ = std::fs::remove_file(SOCKET_PATH);
         let listener = UnixListener::bind(SOCKET_PATH).expect("Failed to bind socket");
-        sher_log!(format!("Daemon listening on {}", SOCKET_PATH));
+        let _ = sher_log!(format!("Daemon listening on {}", SOCKET_PATH));
 
         for stream in listener.incoming() {
             if let Ok(mut stream) = stream {

--- a/src/launcher/bookmark_launcher.rs
+++ b/src/launcher/bookmark_launcher.rs
@@ -29,7 +29,7 @@ impl BookmarkLauncher {
                 sher_log!(format!(
                     r#"Failed to gather bookmarks for browser: "{}""#,
                     browser
-                ));
+                ))?;
                 Err(sherlock_error!(
                     SherlockErrorType::UnsupportedBrowser(browser.to_string()),
                     format!("The browser \"<i>{}</i>\" is either not supported or not recognized.\n\

--- a/src/loader/css_loader.rs
+++ b/src/loader/css_loader.rs
@@ -35,7 +35,7 @@ impl Loader {
         })?;
 
         if let Some(current_provider) = get_provider() {
-            sher_log!("Removed current style provider");
+            sher_log!("Removed current style provider")?;
             gtk4::style_context_remove_provider_for_display(&display, &current_provider);
         }
 
@@ -64,7 +64,7 @@ impl Loader {
                 gtk4::STYLE_PROVIDER_PRIORITY_USER,
             );
             set_provider(usr_provider.downgrade());
-            sher_log!("Added new user style provider");
+            sher_log!("Added new user style provider")?;
         } else {
             let _result = sherlock_error!(
                 SherlockErrorType::FileExistError(config.files.css.clone()),


### PR DESCRIPTION
If `~/.sherlock/` doesn't exist, the program panics when trying to open the logfile

```
thread '<unnamed>' panicked at src/utils/logging.rs:18:10: src/utils/logging.rs:18 - Failed to open logfile: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```