### PR TITLE
XDG Base Directory Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,6 +2555,7 @@ dependencies = [
  "tokio",
  "toml",
  "wayland-protocols 0.32.8",
+ "xdg",
  "zbus",
 ]
 
@@ -3552,6 +3553,12 @@ checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
 dependencies = [
  "nix 0.24.3",
 ]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ async-channel = "2.3.1"
 async-std = "1.13.1"
 futures = "0.3.31"
 levenshtein = "1.0.5"
+xdg = "3.0.0"
 
 [package.metadata]
 assets = ["resources/*"]

--- a/src/actions/util.rs
+++ b/src/actions/util.rs
@@ -6,7 +6,8 @@ use crate::{
     loader::application_loader::{get_applications_dir, get_desktop_files},
     utils::{
         errors::{SherlockError, SherlockErrorType},
-        files::{home_dir, read_lines},
+        files::read_lines,
+        paths,
     },
 };
 use crate::{sherlock_error, CONFIG};
@@ -29,11 +30,12 @@ pub fn clear_cached_files() -> Result<(), SherlockError> {
     let config = CONFIG
         .get()
         .ok_or_else(|| sherlock_error!(SherlockErrorType::ConfigError(None), ""))?;
-    let home = home_dir()?;
+    let cache_dir = paths::get_cache_dir()?;
+
     // Clear sherlocks cache
-    fs::remove_dir_all(home.join(".cache/sherlock")).map_err(|e| {
+    fs::remove_dir_all(&cache_dir).map_err(|e| {
         sherlock_error!(
-            SherlockErrorType::DirRemoveError(String::from("~/.cache/sherlock")),
+            SherlockErrorType::DirRemoveError(cache_dir.to_string_lossy().to_string()),
             e.to_string()
         )
     })?;
@@ -50,10 +52,11 @@ pub fn clear_cached_files() -> Result<(), SherlockError> {
 }
 
 pub fn reset_app_counter() -> Result<(), SherlockError> {
-    let home = home_dir()?;
-    fs::remove_file(home.join(".sherlock/counts.json")).map_err(|e| {
+    let data_dir = paths::get_data_dir()?;
+    let counts_path = data_dir.join("counts.json");
+    fs::remove_file(&counts_path).map_err(|e| {
         sherlock_error!(
-            SherlockErrorType::FileRemoveError(home.join(".sherlock/counts.json")),
+            SherlockErrorType::FileRemoveError(counts_path),
             e.to_string()
         )
     })

--- a/src/launcher/theme_picker.rs
+++ b/src/launcher/theme_picker.rs
@@ -2,13 +2,12 @@ use std::collections::HashSet;
 use std::fs::write;
 use std::path::Path;
 use std::path::PathBuf;
-use tokio::fs::create_dir_all;
 
 use crate::loader::util::AppData;
 use crate::loader::Loader;
 use crate::sherlock_error;
 use crate::utils::errors::{SherlockError, SherlockErrorType};
-use crate::utils::files::home_dir;
+use crate::utils::paths;
 
 use super::LauncherType;
 
@@ -74,10 +73,15 @@ impl ThemePicker {
     }
 
     pub fn get_cached() -> Result<PathBuf, SherlockError> {
-        let home = home_dir()?;
-        let absolute = home.join(".sherlock/theme.txt");
+        let config_dir = paths::get_config_dir()?;
+        let absolute = config_dir.join("theme.txt");
         if let Some(parents) = absolute.parent() {
-            let _ = create_dir_all(parents);
+            std::fs::create_dir_all(parents).map_err(|e| {
+                sherlock_error!(
+                    SherlockErrorType::DirCreateError(parents.to_string_lossy().to_string()),
+                    e.to_string()
+                )
+            })?;
         }
         Ok(absolute)
     }

--- a/src/loader/css_loader.rs
+++ b/src/loader/css_loader.rs
@@ -3,6 +3,7 @@ use gio::glib::WeakRef;
 use gtk4::gdk::Display;
 use gtk4::CssProvider;
 use std::cell::RefCell;
+use std::fs;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
@@ -66,11 +67,12 @@ impl Loader {
             set_provider(usr_provider.downgrade());
             sher_log!("Added new user style provider")?;
         } else {
-            let _result = sherlock_error!(
-                SherlockErrorType::FileExistError(config.files.css.clone()),
-                "Using default css"
-            )
-            .insert(false);
+            fs::write(&theme, "").map_err(|e| {
+                sherlock_error!(
+                    SherlockErrorType::FileWriteError(theme.clone()),
+                    e.to_string()
+                )
+            })?;
         }
 
         drop(provider);

--- a/src/loader/util.rs
+++ b/src/loader/util.rs
@@ -6,7 +6,6 @@ use serde_json::Value;
 use std::{
     borrow::Cow,
     collections::{BTreeSet, HashMap, HashSet},
-    env,
     fmt::Debug,
     fs::{self, File},
     hash::{Hash, Hasher},
@@ -18,6 +17,7 @@ use crate::{
     utils::{
         errors::{SherlockError, SherlockErrorType},
         files::{expand_path, home_dir},
+        paths,
     },
 };
 
@@ -261,18 +261,12 @@ pub struct CounterReader {
 }
 impl CounterReader {
     pub fn new() -> Result<Self, SherlockError> {
-        let home = env::var("HOME").map_err(|e| {
-            sherlock_error!(
-                SherlockErrorType::EnvVarNotFoundError("HOME".to_string()),
-                e.to_string()
-            )
-        })?;
-        let home_dir = PathBuf::from(home);
-        let path = home_dir.join(".sherlock/counts.json");
+        let data_dir = paths::get_data_dir()?;
+        let path = data_dir.join("counts.json");
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(|e| {
                 sherlock_error!(
-                    SherlockErrorType::DirCreateError(".sherlock".to_string()),
+                    SherlockErrorType::DirCreateError(parent.to_string_lossy().to_string()),
                     e.to_string()
                 )
             })?;

--- a/src/loader/util.rs
+++ b/src/loader/util.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub struct RawLauncher {
     pub name: Option<String>,
     pub alias: Option<String>,

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -20,6 +20,7 @@ use crate::g_subclasses::sherlock_row::SherlockRow;
 use crate::loader::Loader;
 use crate::utils::config::default_modkey_ascii;
 use crate::utils::errors::{SherlockError, SherlockErrorType};
+use crate::utils::paths;
 use crate::{sherlock_error, CONFIG};
 
 use super::tiles::util::TextViewTileBuilder;
@@ -178,18 +179,12 @@ pub struct SherlockCounter {
 }
 impl SherlockCounter {
     pub fn new() -> Result<Self, SherlockError> {
-        let home = std::env::var("HOME").map_err(|e| {
-            sherlock_error!(
-                SherlockErrorType::EnvVarNotFoundError("HOME".to_string()),
-                e.to_string()
-            )
-        })?;
-        let home_dir = PathBuf::from(home);
-        let path = home_dir.join(".cache/sherlock/sherlock_count");
+        let cache_dir = paths::get_cache_dir()?;
+        let path = cache_dir.join("sherlock_count");
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(|e| {
                 sherlock_error!(
-                    SherlockErrorType::DirCreateError(".sherlock".to_string()),
+                    SherlockErrorType::DirCreateError(parent.to_string_lossy().to_string()),
                     e.to_string()
                 )
             })?;

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -9,6 +9,7 @@ use std::{
 use super::{
     errors::{SherlockError, SherlockErrorType},
     files::{expand_path, home_dir},
+    paths,
 };
 use crate::{actions::util::parse_default_browser, loader::Loader, sherlock_error};
 
@@ -255,7 +256,7 @@ impl SherlockConfig {
         let home = home_dir()?;
         let mut path = match &sherlock_flags.config {
             Some(path) => expand_path(path, &home),
-            _ => home.join(".config/sherlock/config.toml"),
+            _ => paths::get_config_dir()?.join("config.toml"),
         };
         // logic to either use json or toml
         let mut filetype: String = String::new();
@@ -742,25 +743,25 @@ pub fn default_currency() -> String {
 }
 
 pub fn default_cache() -> PathBuf {
-    PathBuf::from("~/.cache/sherlock/sherlock_desktop_cache.json")
+    paths::get_cache_dir().unwrap().join("sherlock_desktop_cache.json")
 }
 pub fn default_config() -> PathBuf {
-    PathBuf::from("~/.config/sherlock/config.toml")
+    paths::get_config_dir().unwrap().join("config.toml")
 }
 pub fn default_fallback() -> PathBuf {
-    PathBuf::from("~/.config/sherlock/fallback.json")
+    paths::get_config_dir().unwrap().join("fallback.json")
 }
 pub fn default_css() -> PathBuf {
-    PathBuf::from("~/.config/sherlock/main.css")
+    paths::get_config_dir().unwrap().join("main.css")
 }
 pub fn default_alias() -> PathBuf {
-    PathBuf::from("~/.config/sherlock/sherlock_alias.json")
+    paths::get_config_dir().unwrap().join("sherlock_alias.json")
 }
 pub fn default_ignore() -> PathBuf {
-    PathBuf::from("~/.config/sherlock/sherlockignore")
+    paths::get_config_dir().unwrap().join("sherlockignore")
 }
 pub fn default_actions() -> PathBuf {
-    PathBuf::from("~/.config/sherlock/sherlock_actions.json")
+    paths::get_config_dir().unwrap().join("sherlock_actions.json")
 }
 
 pub fn default_true() -> bool {
@@ -776,7 +777,7 @@ pub fn default_backdrop_edge() -> String {
     String::from("top")
 }
 pub fn default_icon_paths() -> Vec<String> {
-    vec![String::from("~/.config/sherlock/icons/")]
+    vec![paths::get_config_dir().unwrap().join("icons/").to_str().unwrap().to_string()]
 }
 pub fn default_icon_size() -> i32 {
     22

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -334,13 +334,20 @@ impl SherlockConfig {
             }
             Err(e) => match e.kind() {
                 std::io::ErrorKind::NotFound => {
-                    let error =
-                        sherlock_error!(SherlockErrorType::FileExistError(path), e.to_string());
-
                     let mut config = SherlockConfig::default();
+                    let config_str = match filetype.as_str() {
+                        "json" => serde_json::to_string_pretty(&config).unwrap(),
+                        _ => toml::to_string(&config).unwrap(),
+                    };
+                    fs::write(&path, config_str).map_err(|e| {
+                        sherlock_error!(
+                            SherlockErrorType::FileWriteError(path.clone()),
+                            e.to_string()
+                        )
+                    })?;
 
                     config = SherlockConfig::apply_flags(sherlock_flags, config);
-                    Ok((config, vec![error]))
+                    Ok((config, vec![]))
                 }
                 _ => Err(sherlock_error!(
                     SherlockErrorType::FileReadError(path),
@@ -743,7 +750,9 @@ pub fn default_currency() -> String {
 }
 
 pub fn default_cache() -> PathBuf {
-    paths::get_cache_dir().unwrap().join("sherlock_desktop_cache.json")
+    paths::get_cache_dir()
+        .unwrap()
+        .join("sherlock_desktop_cache.json")
 }
 pub fn default_config() -> PathBuf {
     paths::get_config_dir().unwrap().join("config.toml")
@@ -761,7 +770,9 @@ pub fn default_ignore() -> PathBuf {
     paths::get_config_dir().unwrap().join("sherlockignore")
 }
 pub fn default_actions() -> PathBuf {
-    paths::get_config_dir().unwrap().join("sherlock_actions.json")
+    paths::get_config_dir()
+        .unwrap()
+        .join("sherlock_actions.json")
 }
 
 pub fn default_true() -> bool {
@@ -777,7 +788,12 @@ pub fn default_backdrop_edge() -> String {
     String::from("top")
 }
 pub fn default_icon_paths() -> Vec<String> {
-    vec![paths::get_config_dir().unwrap().join("icons/").to_str().unwrap().to_string()]
+    vec![paths::get_config_dir()
+        .unwrap()
+        .join("icons/")
+        .to_str()
+        .unwrap()
+        .to_string()]
 }
 pub fn default_icon_size() -> i32 {
     22

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -5,18 +5,18 @@ use chrono::Local;
 use once_cell::sync::Lazy;
 
 use crate::sherlock_error;
-use crate::utils::{errors::SherlockError, errors::SherlockErrorType, files::home_dir};
+use crate::utils::{errors::SherlockError, errors::SherlockErrorType, paths};
 
 static LOG_FILE: Lazy<Result<Mutex<std::fs::File>, SherlockError>> = Lazy::new(|| {
-    let sherlock_dir = home_dir()?.join(".sherlock/");
-    fs::create_dir_all(&sherlock_dir).map_err(|e| {
+    let cache_dir = paths::get_cache_dir()?;
+    fs::create_dir_all(&cache_dir).map_err(|e| {
         sherlock_error!(
-            SherlockErrorType::DirCreateError(sherlock_dir.display().to_string()),
+            SherlockErrorType::DirCreateError(cache_dir.display().to_string()),
             e.to_string()
         )
     })?;
 
-    let location = sherlock_dir.join("sherlock.log");
+    let location = cache_dir.join("sherlock.log");
 
     let file = OpenOptions::new()
         .create(true)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,3 +2,4 @@ pub mod config;
 pub mod errors;
 pub mod files;
 pub mod logging;
+pub mod paths;

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -1,0 +1,96 @@
+use crate::utils::files;
+use std::{fs, path::PathBuf};
+
+fn get_xdg_dirs() -> xdg::BaseDirectories {
+    xdg::BaseDirectories::with_prefix("sherlock")
+}
+
+fn legacy_path() -> Result<PathBuf, crate::utils::errors::SherlockError> {
+    let home_dir = files::home_dir()?;
+    Ok(home_dir.join(".sherlock"))
+}
+
+/// Returns the configuration directory.
+///
+/// It first checks for the legacy `~/.sherlock` directory. If it exists, it returns that path.
+/// Otherwise, it returns the XDG standard configuration path, `$XDG_CONFIG_HOME/sherlock`.
+/// If the directory does not exist, it will be created.
+pub fn get_config_dir() -> Result<PathBuf, crate::utils::errors::SherlockError> {
+    let legacy_path = legacy_path()?;
+    if legacy_path.exists() {
+        return Ok(legacy_path);
+    }
+    let xdg_dirs = get_xdg_dirs();
+    let dir = xdg_dirs.get_config_home().ok_or_else(|| {
+        crate::sherlock_error!(
+            crate::utils::errors::SherlockErrorType::DirReadError(
+                "Could not find config directory".to_string()
+            ),
+            ""
+        )
+    })?;
+    fs::create_dir_all(&dir).map_err(|_| {
+        crate::sherlock_error!(
+            crate::utils::errors::SherlockErrorType::DirCreateError(
+                "Could not create config directory".to_string()
+            ),
+            ""
+        )
+    })?;
+    Ok(dir)
+}
+
+/// Returns the data directory.
+///
+/// It first checks for the legacy `~/.sherlock` directory. If it exists, it returns that path.
+/// Otherwise, it returns the XDG standard data path, `$XDG_DATA_HOME/sherlock`.
+/// If the directory does not exist, it will be created.
+pub fn get_data_dir() -> Result<PathBuf, crate::utils::errors::SherlockError> {
+    let legacy_path = legacy_path()?;
+    if legacy_path.exists() {
+        return Ok(legacy_path);
+    }
+    let xdg_dirs = get_xdg_dirs();
+    let dir = xdg_dirs.get_data_home().ok_or_else(|| {
+        crate::sherlock_error!(
+            crate::utils::errors::SherlockErrorType::DirReadError(
+                "Could not find data directory".to_string()
+            ),
+            ""
+        )
+    })?;
+    fs::create_dir_all(&dir).map_err(|_| {
+        crate::sherlock_error!(
+            crate::utils::errors::SherlockErrorType::DirCreateError(
+                "Could not create data directory".to_string()
+            ),
+            ""
+        )
+    })?;
+    Ok(dir)
+}
+
+/// Returns the cache directory.
+///
+/// This function returns the XDG standard cache path, `$XDG_CACHE_HOME/sherlock`.
+/// If the directory does not exist, it will be created.
+pub fn get_cache_dir() -> Result<PathBuf, crate::utils::errors::SherlockError> {
+    let xdg_dirs = get_xdg_dirs();
+    let dir = xdg_dirs.get_cache_home().ok_or_else(|| {
+        crate::sherlock_error!(
+            crate::utils::errors::SherlockErrorType::DirReadError(
+                "Could not find cache directory".to_string()
+            ),
+            ""
+        )
+    })?;
+    fs::create_dir_all(&dir).map_err(|_| {
+        crate::sherlock_error!(
+            crate::utils::errors::SherlockErrorType::DirCreateError(
+                "Could not create cache directory".to_string()
+            ),
+            ""
+        )
+    })?;
+    Ok(dir)
+}


### PR DESCRIPTION
- Should keep legacy configs working (might need testing).
- Replaces cache and other instances as well.
- Replaces hard-coded ~/.config, ~/.cache, etc. references as well with `xdg`, allowing use of XDG paths set by the user.

As a side question, I'm not entirely sure why config needs to support both json and toml? Seems like complexity that's not really necessary.