### PR TITLE
Add an option to enable left/right arrow keys in search bar instead of list navigation

### DIFF
--- a/src/g_subclasses/tile_item/mod.rs
+++ b/src/g_subclasses/tile_item/mod.rs
@@ -250,7 +250,11 @@ impl TileItem {
         }
     }
     pub fn replace_tile(&self, tile: &Widget) {
-        self.imp().update_handler.borrow_mut().replace_tile(tile);
+        if let Ok(mut handler) = self.imp().update_handler.try_borrow_mut() {
+            handler.replace_tile(tile);
+        } else {
+            eprintln!("Warning: Could not borrow update_handler mutably in replace_tile");
+        }
     }
     pub fn update(&self, keyword: &str) -> Option<()> {
         let imp = self.imp();

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -575,6 +575,8 @@ fn nav_event(
     let custom_controller = custom_handler.borrow().get_controller();
     let stack_page = Rc::clone(stack_page);
     let multi = ConfigGuard::read().map_or(false, |c| c.runtime.multi);
+    let use_leftright_arrows_insearchbar =
+        ConfigGuard::read().map_or(false, |c| c.behavior.use_leftright_arrows_insearchbar);
     event_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
     event_controller.connect_key_pressed({
         let search_bar = search_bar.clone();
@@ -604,7 +606,7 @@ fn nav_event(
 
                 // Custom previous key
                 Key::Up => key_actions.on_prev(),
-                Key::Left => key_actions.on_prev(),
+                Key::Left if use_leftright_arrows_insearchbar => key_actions.on_prev(),
                 _ if matches(binds.up, binds.up_mod) => {
                     key_actions.on_prev();
                 }
@@ -614,7 +616,7 @@ fn nav_event(
 
                 // Custom next key
                 Key::Down => key_actions.on_next(),
-                Key::Right => key_actions.on_next(),
+                Key::Right if use_leftright_arrows_insearchbar => key_actions.on_next(),
                 _ if matches(binds.down, binds.down_mod) => {
                     key_actions.on_next();
                 }

--- a/src/utils/config/imp.rs
+++ b/src/utils/config/imp.rs
@@ -68,6 +68,7 @@ impl Default for ConfigBehavior {
             animate: true,
             global_prefix: None,
             global_flags: None,
+            use_leftright_arrows_insearchbar: false,
         }
     }
 }

--- a/src/utils/config/mod.rs
+++ b/src/utils/config/mod.rs
@@ -134,6 +134,8 @@ pub struct ConfigBehavior {
     pub global_prefix: Option<String>,
     #[serde(default)]
     pub global_flags: Option<String>,
+    #[serde(default = "OtherDefaults::bool_true")]
+    pub use_leftright_arrows_insearchbar: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]


### PR DESCRIPTION
The change adds an option **use_leftright_arrows_insearchbar** in the configuration under the section **[behavior]**. 

If the options is set to true the left and right arrow keys can be used to move the cursor in the search bar textbox which also includes being able to select text with shift and ctrl modifiers

If the option is set to false the right arrow key makes the selection in the list go down and the left arrow key makes the selection in the list go up.
