### PR TITLE
Use `nixpkgs-unstable` instead of `nixos-24.11`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 # this is mostly from https://fasterthanli.me/series/building-a-rust-service-with-nix/part-10#a-flake-with-derivation
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
     flake-parts.url = "github:hercules-ci/flake-parts";
     rust-overlay = {


### PR DESCRIPTION
Unstable branch gets updates the fastest. Also, crane was throwing error `evaluation warning: crane requires at least nixpkgs-25.05, supplied nixpkgs-24.11`. This should be fixed now.