### PR TITLE
Add placeholder option to CLI interface

### DIFF
--- a/src/launcher/emoji_picker.rs
+++ b/src/launcher/emoji_picker.rs
@@ -22,7 +22,6 @@ use crate::ui::context::make_emoji_context;
 use crate::ui::g_templates::GridSearchUi;
 use crate::ui::key_actions::EmojiKeyActions;
 use crate::ui::util::{ConfKeys, ContextUI, SearchHandler};
-use crate::utils::config::ConfigGuard;
 use crate::utils::errors::{SherlockError, SherlockErrorType};
 
 #[derive(Clone, Debug, Deserialize, Serialize, Copy)]
@@ -271,11 +270,10 @@ fn construct(
     ),
     SherlockError,
 > {
-    let config = ConfigGuard::read()?;
     let emojies = EmojiPicker::load(skin_tone)?;
     let search_text = Rc::new(RefCell::new(String::new()));
     // Initialize the builder with the correct path
-    let ui = GridSearchUi::new(config.behavior.placeholder.as_deref());
+    let ui = GridSearchUi::new();
     let imp = ui.imp();
 
     let (context, revealer) = make_emoji_context();
@@ -500,4 +498,3 @@ fn make_sorter(search_text: &Rc<RefCell<String>>) -> CustomSorter {
         }
     })
 }
-

--- a/src/launcher/emoji_picker.rs
+++ b/src/launcher/emoji_picker.rs
@@ -22,6 +22,7 @@ use crate::ui::context::make_emoji_context;
 use crate::ui::g_templates::GridSearchUi;
 use crate::ui::key_actions::EmojiKeyActions;
 use crate::ui::util::{ConfKeys, ContextUI, SearchHandler};
+use crate::utils::config::ConfigGuard;
 use crate::utils::errors::{SherlockError, SherlockErrorType};
 
 #[derive(Clone, Debug, Deserialize, Serialize, Copy)]
@@ -270,10 +271,11 @@ fn construct(
     ),
     SherlockError,
 > {
+    let config = ConfigGuard::read()?;
     let emojies = EmojiPicker::load(skin_tone)?;
     let search_text = Rc::new(RefCell::new(String::new()));
     // Initialize the builder with the correct path
-    let ui = GridSearchUi::new();
+    let ui = GridSearchUi::new(config.behavior.placeholder.as_deref());
     let imp = ui.imp();
 
     let (context, revealer) = make_emoji_context();
@@ -498,3 +500,4 @@ fn make_sorter(search_text: &Rc<RefCell<String>>) -> CustomSorter {
         }
     })
 }
+

--- a/src/loader/flag_loader.rs
+++ b/src/loader/flag_loader.rs
@@ -84,7 +84,7 @@ impl SherlockFlags {
             multi: check_flag_existence("--multi"),
             photo_mode: check_flag_existence("--photo"),
             input: Self::extract_flag_value::<bool>(&args, "--input", None),
-            placeholder: Self::extract_flag_value::<String>(&args, "--placeholder", None),
+            placeholder: Self::extract_flag_value::<String>(&args, "--placeholder", Some("-p")),
         })
     }
 }
@@ -115,7 +115,7 @@ pub fn flag_documentation() -> Result<(), SherlockError> {
         ),
         ("\nBEHAVIOR:", ""),
         (
-            "--placeholder",
+            "-p, --placeholder",
             "Overwrite the placeholder text of the search bar.",
         ),
         (

--- a/src/loader/flag_loader.rs
+++ b/src/loader/flag_loader.rs
@@ -84,6 +84,7 @@ impl SherlockFlags {
             multi: check_flag_existence("--multi"),
             photo_mode: check_flag_existence("--photo"),
             input: Self::extract_flag_value::<bool>(&args, "--input", None),
+            placeholder: Self::extract_flag_value::<String>(&args, "--placeholder", None),
         })
     }
 }
@@ -113,6 +114,10 @@ pub fn flag_documentation() -> Result<(), SherlockError> {
             "Specify the directly Sherlock will look for its configuration in.",
         ),
         ("\nBEHAVIOR:", ""),
+        (
+            "--placeholder",
+            "Overwrite the placeholder text of the search bar.",
+        ),
         (
             "--daemonize",
             "If this flag is set, Sherlock will run in daemon mode.",

--- a/src/ui/g_templates/grid_search.rs
+++ b/src/ui/g_templates/grid_search.rs
@@ -59,7 +59,7 @@ mod imp {
 }
 
 use gtk4::glib;
-use gtk4::prelude::WidgetExt;
+use gtk4::prelude::{EntryExt, WidgetExt};
 use gtk4::subclass::prelude::ObjectSubclassIsExt;
 glib::wrapper! {
     pub struct GridSearchUi(ObjectSubclass<imp::GridSearchUi>)
@@ -68,9 +68,10 @@ glib::wrapper! {
 }
 
 impl GridSearchUi {
-    pub fn new() -> Self {
+    pub fn new(placeholder: Option<&str>) -> Self {
         let ui = glib::Object::new::<Self>();
         let imp = ui.imp();
+        imp.search_bar.set_placeholder_text(Some(placeholder.unwrap_or("Search:")));
         imp.search_icon_holder.add_css_class("search");
         imp.results.set_focusable(false);
         ui

--- a/src/ui/g_templates/grid_search.rs
+++ b/src/ui/g_templates/grid_search.rs
@@ -67,13 +67,17 @@ glib::wrapper! {
         @implements gtk4::Buildable;
 }
 
+use crate::utils::config::ConfigGuard;
 impl GridSearchUi {
-    pub fn new(placeholder: Option<&str>) -> Self {
+    pub fn new() -> Self {
         let ui = glib::Object::new::<Self>();
         let imp = ui.imp();
-        imp.search_bar.set_placeholder_text(Some(placeholder.unwrap_or("Search:")));
         imp.search_icon_holder.add_css_class("search");
         imp.results.set_focusable(false);
+        if let Ok(config) = ConfigGuard::read() {
+            imp.search_bar
+                .set_placeholder_text(Some(&config.appearance.placeholder));
+        }
         ui
     }
 }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -303,7 +303,7 @@ fn construct_window(
     main_overlay.add_overlay(&revealer);
 
     imp.search_bar
-        .set_placeholder_text(Some(config.behavior.placeholder.as_deref().unwrap_or("Search:")));
+        .set_placeholder_text(Some(&config.appearance.placeholder));
 
     // Update the search icon
     imp.search_icon.set_icon(

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -302,6 +302,9 @@ fn construct_window(
     main_overlay.set_child(Some(&ui));
     main_overlay.add_overlay(&revealer);
 
+    imp.search_bar
+        .set_placeholder_text(Some(config.behavior.placeholder.as_deref().unwrap_or("Search:")));
+
     // Update the search icon
     imp.search_icon.set_icon(
         Some(&config.search_bar_icon.icon),

--- a/src/utils/config/config_impl.rs
+++ b/src/utils/config/config_impl.rs
@@ -199,6 +199,10 @@ impl SherlockConfig {
         config.runtime.field = sherlock_flags.field.take();
         config.runtime.daemonize = sherlock_flags.daemonize;
 
+        if let Some(placeholder) = sherlock_flags.placeholder.take() {
+            config.behavior.placeholder = Some(placeholder);
+        }
+
         config
     }
 }

--- a/src/utils/config/config_impl.rs
+++ b/src/utils/config/config_impl.rs
@@ -200,7 +200,7 @@ impl SherlockConfig {
         config.runtime.daemonize = sherlock_flags.daemonize;
 
         if let Some(placeholder) = sherlock_flags.placeholder.take() {
-            config.behavior.placeholder = Some(placeholder);
+            config.appearance.placeholder = placeholder;
         }
 
         config

--- a/src/utils/config/defaults.rs
+++ b/src/utils/config/defaults.rs
@@ -234,4 +234,7 @@ impl OtherDefaults {
     pub fn search_icon_back() -> String {
         String::from("sherlock-back")
     }
+    pub fn placeholder() -> String {
+        String::from("Search:")
+    }
 }

--- a/src/utils/config/flags.rs
+++ b/src/utils/config/flags.rs
@@ -27,6 +27,7 @@ pub struct SherlockFlags {
     pub multi: bool,
     pub photo_mode: bool,
     pub input: Option<bool>,
+    pub placeholder: Option<String>,
 }
 
 impl SherlockFlags {

--- a/src/utils/config/imp.rs
+++ b/src/utils/config/imp.rs
@@ -71,6 +71,7 @@ impl Default for ConfigBehavior {
             global_prefix: None,
             global_flags: None,
             use_lr_nav: false,
+            placeholder: None,
         }
     }
 }

--- a/src/utils/config/imp.rs
+++ b/src/utils/config/imp.rs
@@ -59,6 +59,7 @@ impl Default for ConfigAppearance {
             opacity: 1.0,
             mod_key_ascii: BindDefaults::modkey_ascii(),
             num_shortcuts: 5,
+            placeholder: OtherDefaults::placeholder(),
         }
     }
 }
@@ -71,7 +72,6 @@ impl Default for ConfigBehavior {
             global_prefix: None,
             global_flags: None,
             use_lr_nav: false,
-            placeholder: None,
         }
     }
 }

--- a/src/utils/config/mod.rs
+++ b/src/utils/config/mod.rs
@@ -140,6 +140,8 @@ pub struct ConfigBehavior {
     pub global_flags: Option<String>,
     #[serde(default = "OtherDefaults::bool_true")]
     pub use_lr_nav: bool,
+    #[serde(default)]
+    pub placeholder: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/utils/config/mod.rs
+++ b/src/utils/config/mod.rs
@@ -127,6 +127,8 @@ pub struct ConfigAppearance {
     pub mod_key_ascii: Vec<String>,
     #[serde(default = "OtherDefaults::five")]
     pub num_shortcuts: u8,
+    #[serde(default = "OtherDefaults::placeholder")]
+    pub placeholder: String,
 }
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ConfigBehavior {
@@ -140,8 +142,6 @@ pub struct ConfigBehavior {
     pub global_flags: Option<String>,
     #[serde(default = "OtherDefaults::bool_true")]
     pub use_lr_nav: bool,
-    #[serde(default)]
-    pub placeholder: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]


### PR DESCRIPTION
First of all, thanks for the great tool, it's really great.

# Description
This PR adds `--placeholder` option which allows overwriting currently hardcoded `Search:`.
Launchers like dmenu, rofi, walker all support this, which allows to use them as a menu system 
(Omarchy is a great example of such use case).

# Implementation
I must say that I have zero experience with Rust. All the code was generated by Gemini AI.
I reviewed its change and double checked if it actually works.
However, I realize that the implementation may not be up to the standards and it might require some changes (or maybe even rewritten entirely).

So please let me know what you think. I'm willing to make the necessary changes.
If you think that this PR is not how you would like to make this feature work, then feel free to decline.

# Screenshots
<img width="1794" height="1252" alt="image" src="https://github.com/user-attachments/assets/5e3e77d1-7853-4cf3-b6eb-6c0eb67368ba" />
<img width="1750" height="1368" alt="20250820-133631" src="https://github.com/user-attachments/assets/62a2b7b9-b659-4796-9b96-6879327746d1" />

P.S. Thanks again for sherlock!