### PR TITLE
mpris: Make metadata fields optional

### DIFF
--- a/src/launcher/audio_launcher.rs
+++ b/src/launcher/audio_launcher.rs
@@ -24,18 +24,16 @@ impl MusicPlayerLauncher {
     /// image: Pixbuf
     /// was_cached: bool
     pub async fn get_image(&self) -> Option<(Pixbuf, bool)> {
-        let loc = match &self.mpris.metadata.art.split("/").last() {
-            Some(s) => s.to_string(),
-            _ => return None,
-        };
+        let art_url = self.mpris.metadata.art.as_ref()?;
+        let loc = art_url.split("/").last()?.to_string();
         let mut was_cached = true;
         let bytes = match MusicPlayerLauncher::read_cached_cover(&loc) {
             Ok(b) => b,
             Err(_) => {
-                if self.mpris.metadata.art.starts_with("file") {
-                    MusicPlayerLauncher::read_image_file(&self.mpris.metadata.art).ok()?
+                if art_url.starts_with("file") {
+                    MusicPlayerLauncher::read_image_file(art_url).ok()?
                 } else {
-                    let response = reqwest::get(&self.mpris.metadata.art).await.ok()?;
+                    let response = reqwest::get(art_url).await.ok()?;
                     let bytes = response.bytes().await.ok()?;
                     let _ = MusicPlayerLauncher::cache_cover(&bytes, &loc);
                     was_cached = false;

--- a/src/launcher/utils.rs
+++ b/src/launcher/utils.rs
@@ -1,7 +1,6 @@
 use serde::Deserialize;
 use serde::Serialize;
-use zbus::zvariant::DeserializeDict;
-use zbus::zvariant::Type;
+use zbus::zvariant::{DeserializeDict, Type};
 
 #[derive(DeserializeDict, Type, Debug, Clone, Default)]
 #[zvariant(signature = "a{sv}")]
@@ -18,19 +17,19 @@ pub struct MprisData {
 #[allow(unused)]
 pub struct MetaData {
     #[zvariant(rename = "xesam:title")]
-    pub title: String,
+    pub title: Option<String>,
 
     #[zvariant(rename = "xesam:album")]
-    pub album: String,
+    pub album: Option<String>,
 
     #[zvariant(rename = "xesam:artist")]
-    pub artists: Vec<String>,
+    pub artists: Option<Vec<String>>,
 
     #[zvariant(rename = "xesam:url")]
-    pub url: String,
+    pub url: Option<String>,
 
     #[zvariant(rename = "mpris:artUrl")]
-    pub art: String,
+    pub art: Option<String>,
 }
 
 pub fn to_title_case(input_str: &str) -> String {

--- a/src/ui/tiles/mpris_tile.rs
+++ b/src/ui/tiles/mpris_tile.rs
@@ -94,9 +94,23 @@ impl MusicTileHandler {
                 }
                 // Update mpris and ui title and artist
                 *mpris = new;
-                imp.category
-                    .set_text(&mpris.mpris.metadata.artists.join(", "));
-                imp.title.set_text(&mpris.mpris.metadata.title);
+                let artists_text = mpris
+                    .mpris
+                    .metadata
+                    .artists
+                    .as_ref()
+                    .map(|artists| artists.join(", "))
+                    .unwrap_or_else(|| "Unknown Artist".to_string());
+                imp.category.set_text(&artists_text);
+
+                let title_text = mpris
+                    .mpris
+                    .metadata
+                    .title
+                    .as_ref()
+                    .map(|title| title.clone())
+                    .unwrap_or_else(|| "Unknown Title".to_string());
+                imp.title.set_text(&title_text);
                 self.attrs
                     .borrow_mut()
                     .entry("player".to_string())


### PR DESCRIPTION
Using Chrome to play music would not reveal the audio launcher, as deserialize silently failed on some missing xesam fields.

Make all fields optional and just use what is there.